### PR TITLE
Remove WindowsClient from imports

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,7 @@
 
 from http import client
 from fido2.hid import CtapHidDevice
-from fido2.client import Fido2Client, WindowsClient, UserInteraction, ClientError, _Ctap1ClientBackend
+from fido2.client import Fido2Client, UserInteraction, ClientError, _Ctap1ClientBackend
 from fido2.attestation import FidoU2FAttestation
 from fido2.ctap2.pin import ClientPin
 from fido2.server import Fido2Server


### PR DESCRIPTION
In version [2.0.0](https://github.com/Yubico/python-fido2/blob/ed072c1b4fd4127a72758f00b55e0f3b7242096c/NEWS#L12) of python-fido2, importing `WindowsClient` in a non-Windows OS raises an `ImportError`. Since `WindowsClient` is not used it may be removed to prevent the error.