### PR TITLE
Fix wrong determination by using #if instead of #ifndef of conditional compilation macro for OATH and OTP

### DIFF
--- a/src/fido/fido.c
+++ b/src/fido/fido.c
@@ -486,7 +486,7 @@ extern void init_otp();
 extern bool needs_power_cycle;
 void init_fido() {
     scan_all();
-#ifdef ENABLE_OTP_APP
+#if ENABLE_OTP_APP
     init_otp();
 #endif
     needs_power_cycle = false;

--- a/src/fido/management.c
+++ b/src/fido/management.c
@@ -42,7 +42,7 @@ int man_select(app_t *a, uint8_t force) {
     apdu.ne = res_APDU_size;
     if (force) {
         scan_all();
-#ifdef ENABLE_OTP_APP
+#if ENABLE_OTP_APP
         init_otp();
 #endif
     }

--- a/src/fido/otp.c
+++ b/src/fido/otp.c
@@ -222,7 +222,7 @@ int otp_button_pressed(uint8_t slot) {
     if (otp_config->cfg_flags & CHAL_YUBICO && otp_config->tkt_flags & CHAL_RESP) {
         return 2;
     }
-#ifdef ENABLE_OATH_APP
+#if ENABLE_OATH_APP
     if (otp_config->tkt_flags & OATH_HOTP) {
         uint8_t tmp_key[KEY_SIZE + 2];
         tmp_key[0] = 0x01;


### PR DESCRIPTION
## Summary

When set option(ENABLE_OATH_APP) and option(ENABLE_OTP_APP) to OFF, It actually creates a macro with a value of 0 instead of undefining it, thus causing the parts that use #ifndef to be compiled incorrectly.

## Details / Impact

Change #ifdef to #if.
No extra effects.

## Testing

It passed the CI of emulation and test, https://github.com/AlanCui4080/pico-fido/actions/runs/22796001475

## Licensing confirmation (required)

By checking the box below, you confirm ALL of the following:

- You are the author of this contribution, or you have the right to contribute it.
- You have read `CONTRIBUTING.md`.
- You agree that this contribution may be merged, used, modified, and redistributed:
  - under the AGPLv3 Community Edition, **and**
  - under any proprietary / commercial / Enterprise editions of this project,
    now or in the future.
- You understand that submitting this PR does not create any support obligation,
  SLA, or guarantee of merge.

**I confirm the above licensing terms:**

- [ x ] Yes, I agree
