### PR TITLE
Allow to change AAGUID at compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -212,3 +212,13 @@ if(NOT ESP_PLATFORM)
         pico_add_extra_outputs(${CMAKE_PROJECT_NAME})
     endif()
 endif()
+
+# Set AAGUID, by default first 16 bytes of SHA256("Pico FIDO2")
+set(AAGUID "89fb94b7-06c9-3673-9b7e-30526d968145" CACHE STRING "Set AAGUID of the authenticator")
+message(STATUS "AAGUID:\t\t\t ${AAGUID}")
+string(REPLACE "-" "" AAGUID "${AAGUID}")
+
+# Transform 112233... to 0x11, 0x22, 0x33, ...
+string(REGEX REPLACE "(..)" "0x\\1, " AAGUID_LIST "${AAGUID}")
+string(REGEX REPLACE ", $" "" AAGUID_LIST "${AAGUID_LIST}")
+add_compile_definitions(AAGUID=${AAGUID_LIST})

--- a/src/fido/cbor.c
+++ b/src/fido/cbor.c
@@ -32,8 +32,7 @@ const bool _btrue = true, _bfalse = false;
 
 int cbor_get_assertion(const uint8_t *data, size_t len, bool next);
 
-const uint8_t aaguid[16] = { 0x89, 0xFB, 0x94, 0xB7, 0x06, 0xC9, 0x36, 0x73, 0x9B, 0x7E, 0x30, 0x52, 0x6D, 0x96, 0x81, 0x45 }; // First 16 bytes of SHA256("Pico FIDO2")
-
+const uint8_t aaguid[16] = { AAGUID };
 const uint8_t *cbor_data = NULL;
 size_t cbor_len = 0;
 uint8_t cbor_cmd = 0;

--- a/tests/pico-fido/test_000_getinfo.py
+++ b/tests/pico-fido/test_000_getinfo.py
@@ -20,10 +20,12 @@
 
 import pytest
 from fido2.client import CtapError
+from fido2.webauthn import Aaguid
 
+DEFAULT_AAGUID = "89fb94b7-06c9-3673-9b7e-30526d968145"
 
-def test_getinfo(device):
-    pass
+def test_getinfo_aaguid(info):
+    assert(info.aaguid == Aaguid.parse(DEFAULT_AAGUID))
 
 
 def test_get_info_version(info):


### PR DESCRIPTION
## Summary

I don't know if it is the correct way to add this feature. I found very useful to be able to change the AAGUID of the device at compile time.

## Details / Impact

Change the AAGUID at compile time:
```bash
cmake -DAAGUID=03a9320f-b88e-4753-887f-6e5c768a47d0 ..
```

## Licensing confirmation (required)

By checking the box below, you confirm ALL of the following:

- You are the author of this contribution, or you have the right to contribute it.
- You have read `CONTRIBUTING.md`.
- You agree that this contribution may be merged, used, modified, and redistributed:
  - under the AGPLv3 Community Edition, **and**
  - under any proprietary / commercial / Enterprise editions of this project,
    now or in the future.
- You understand that submitting this PR does not create any support obligation,
  SLA, or guarantee of merge.

**I confirm the above licensing terms:**

- [ x] Yes, I agree
