### PR TITLE
Enforce alwaysUv on getAssertion

### DIFF
--- a/src/fido/cbor_get_assertion.c
+++ b/src/fido/cbor_get_assertion.c
@@ -284,6 +284,18 @@ int cbor_get_assertion(const uint8_t *data, size_t len, bool next) {
             }
         }
 
+        /* CTAP 2.1 6.2: with alwaysUv set, an assertion requires user verification.
+           makeCredential enforces this (cbor_make_credential.c), getAssertion upstream
+           does not - it only validates pinUvAuthParam when the platform bothers to send
+           one. With AUV advertised in getInfo that is a guarantee we would not keep:
+           registration would ask for the PIN and every subsequent login would not.
+           Same condition and same error as the makeCredential path. */
+        if (get_opts() & FIDO2_OPT_AUV) {
+            if (!file_has_data(ef_pin) || (pinUvAuthParam.present == false && options.uv != ptrue)) {
+                CBOR_ERROR(CTAP2_ERR_PUAT_REQUIRED);
+            }
+        }
+
         if (pinUvAuthParam.present == true) { //6.1
             int ret = verify((uint8_t)pinUvAuthProtocol, paut.data, clientDataHash.data, (uint16_t)clientDataHash.len, pinUvAuthParam.data);
             if (ret != CborNoError) {


### PR DESCRIPTION
### Problem

`authenticatorGetAssertion` never checks the `alwaysUv` option.

`cbor_make_credential.c` enforces it — a request without user verification is
rejected with `CTAP2_ERR_PUAT_REQUIRED`. `cbor_get_assertion.c` has no equivalent:
it validates `pinUvAuthParam` only when the platform happens to send one, and there
is no path that requires it.

So an authenticator that reports `alwaysUv: true` in `getInfo` asks for the PIN at
registration and then silently skips it on every subsequent login. The option
promises user verification on every operation; assertions do not deliver it.

CTAP 2.1 §6.2 requires user verification when `alwaysUv` is set.

### Reproduction

Against the host emulator, with `alwaysUv` enabled and a PIN configured:

```
makeCredential without pinUvAuthParam  ->  PUAT_REQUIRED   (correct)
getAssertion   without pinUvAuthParam  ->  assertion returned, uv flag clear
```

### Fix

Apply the same condition and the same error as the `makeCredential` path, placed
just before the existing `pinUvAuthParam` handling.

After the change, on the same emulator:

```
getAssertion without pinUvAuthParam  ->  PUAT_REQUIRED
getAssertion with    pinUvAuthParam  ->  assertion returned, uv flag set
```

Normal login with a PIN is unaffected; discoverable credentials still resolve.

### Notes

Found while shipping a downstream build that turns `alwaysUv` on by default. Happy
to adjust placement or wording if you would rather handle it elsewhere in the flow.
