### PR TITLE
Allow USB VID/PID to be overridden from the command line

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,8 +17,15 @@
 
 cmake_minimum_required(VERSION 3.13)
 
-set(USB_VID 0x2E8A)
-set(USB_PID 0x10FE)
+# Allow overriding from the command line: idf.py -DUSB_VID=... -DUSB_PID=...
+# The upstream CONFIG_TINYUSB_DESC_CUSTOM_VID path cannot work here: CONFIG_* only
+# exist after project(), while these lines run before it.
+if(NOT DEFINED USB_VID)
+    set(USB_VID 0x2E8A)
+endif()
+if(NOT DEFINED USB_PID)
+    set(USB_PID 0x10FE)
+endif()
 
 if(ESP_PLATFORM)
     set(ENABLE_EDDSA 1)


### PR DESCRIPTION
### Problem

`-DUSB_VID` / `-DUSB_PID` have no effect: `CMakeLists.txt` assigns both
unconditionally at the top, before anything can override them.

On ESP-IDF there is a second path that looks like it should work —
`picokeys_sdk_import.cmake` reads `CONFIG_TINYUSB_DESC_CUSTOM_VID` — but it cannot:
`CONFIG_*` variables only exist after `project()`, and these assignments run before
it. Setting the values in `sdkconfig` therefore does nothing, and the build silently
keeps `2E8A:10FE`.

Reproduced on ESP-IDF v5.5.5, target esp32s3: with
`CONFIG_TINYUSB_DESC_USE_ESPRESSIF_VID=n` and `CONFIG_TINYUSB_DESC_CUSTOM_VID=0x1209`
present in the generated `sdkconfig`, the build still reports
`USB VID/PID: 0x2E8A:0x10FE`.

This matters for anyone building their own device: the README notes that
distributing a binary under a VID/PID you do not own is not allowed, but the
documented way to change it does not work.

### Fix

Guard the two assignments so an externally supplied value wins:

```
idf.py -DUSB_VID=0x1209 -DUSB_PID=0x0001 build
```

Defaults are unchanged, so existing builds behave exactly as before. The `VIDPID=`
presets keep working. Verified on esp32s3; the value now reaches the descriptor.
